### PR TITLE
Add matches method

### DIFF
--- a/piiregex.py
+++ b/piiregex.py
@@ -82,8 +82,12 @@ class PiiRegex(object):
             self.__build_class_attributes_callables()
 
     def any_match(self, text=""):
-        """Scan through all available matches and try to match.
+        """Scan through all available regexes and return whether we found any.
         """
+        return True if self.matches(text=text) else False
+
+    def matches(self, text=""):
+        """Scan through all available regexes and return a list of matches."""
         if text:
             self.text = text
 
@@ -91,13 +95,12 @@ class PiiRegex(object):
             self.__build_regex_class_attributes()
             self.__build_class_attributes_callables()
 
-        matches = []
+        results = []
         for match in regexes.keys():
-            # If we've got a result, add it to matches.
+            # If we've got a match, add it to results.
             if getattr(self, match):
-                matches.append(match)
-
-        return True if matches else False
+                results.append(match)
+        return results
 
     def __build_regex_class_attributes(self):
         """Build regex class attributes."""

--- a/piiregex.py
+++ b/piiregex.py
@@ -76,13 +76,10 @@ class PiiRegex(object):
         self.text = text
 
         # Build class attributes of callables.
-        for k, v in regexes.items():
-            setattr(self, k, regex(self, v)(self))
+        self.__build_regex_class_attributes()
 
         if text:
-            for key in regexes.keys():
-                method = getattr(self, key)
-                setattr(self, key, method())
+            self.__build_class_attributes_callables()
 
     def any_match(self, text=""):
         """Scan through all available matches and try to match.
@@ -91,11 +88,8 @@ class PiiRegex(object):
             self.text = text
 
             # Regenerate class attribute callables.
-            for k, v in regexes.items():
-                setattr(self, k, regex(self, v)(self))
-            for key in regexes.keys():
-                method = getattr(self, key)
-                setattr(self, key, method())
+            self.__build_regex_class_attributes()
+            self.__build_class_attributes_callables()
 
         matches = []
         for match in regexes.keys():
@@ -105,3 +99,13 @@ class PiiRegex(object):
 
         return True if matches else False
 
+    def __build_regex_class_attributes(self):
+        """Build regex class attributes."""
+        for k, v in regexes.items():
+            setattr(self, k, regex(self, v)(self))
+
+    def __build_class_attributes_callables(self):
+        """Build callable class attributes."""
+        for key in regexes.keys():
+            method = getattr(self, key)
+            setattr(self, key, method())

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 from distutils.core import setup
 
-setup(name="piiregex", version="0.0.2", py_modules=["piiregex"])
+setup(name="piiregex", version="0.0.3", py_modules=["piiregex"])
 

--- a/test_piiregex.py
+++ b/test_piiregex.py
@@ -182,3 +182,24 @@ def test_any_match_using_init_method():
     parsed_text = PiiRegex('asdasdasdasdasd')
     assert parsed_text.any_match() is False
 
+
+def test_matches(pii_regex):
+    # This matches a phone number and a zip code.
+    matches = pii_regex.matches('07123 123123')
+    assert len(matches) == 2
+    assert 'ukphones' in matches
+    assert 'zip_codes' in matches
+    # This should match nothing.
+    assert pii_regex.matches('asdasdasdasdasd') == []
+
+
+def test_matches_using_init_method():
+    # This matches a phone number and a zip code.
+    parsed_text = PiiRegex('07123 123123')
+    matches = parsed_text.matches()
+    assert len(matches) == 2
+    assert 'ukphones' in matches
+    assert 'zip_codes' in matches
+    # This should match nothing.
+    parsed_text = PiiRegex('asdasdasdasdasd')
+    assert parsed_text.matches() == []


### PR DESCRIPTION
It would be helpful to be able to get the list of all of the regex matches separately from the boolean method `any_match`. This PR adds a new `matches` method to do just that, and refactors `any_match` to use the new method. It also adds two new unit tests, similar to others in the test suite, to test this new method.

The PR also adds a small refactor to reduce duplicate code by creating two new helper methods for building the regex class attributes and callables: `__build_regex_class_attributes` and `__build_class_attributes_callables`.